### PR TITLE
Optimize investors block

### DIFF
--- a/src/components/InvestorsCompanies/InvestorsCompanies/InvestorsCompanies.jsx
+++ b/src/components/InvestorsCompanies/InvestorsCompanies/InvestorsCompanies.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import ModalCompanies from '../ModalCompanies/ModalCompanies';
 import { CompaniesList, CompanyWrapper } from './InvestorsCompanies.styled';
-import { nanoid } from 'nanoid';
 import defaultImage from 'src/assets/investors/default-img.png';
 import { makerAnimParams } from '../../../helpers/makerAnimParams';
 import { useMediaQuery } from 'react-responsive';
@@ -27,8 +26,11 @@ const InvestorsCompanies = ({ companies: companiesData }) => {
         <CompaniesList
           $anim={makerAnimParams(companiesData.length, isDesktop, isTablet)}
         >
-          {Array.from([...companiesData, ...companiesData]).map((company) => (
-            <li key={nanoid()}>
+          {Array.from([...companiesData, ...companiesData]).map((company, index) => (
+            <li
+              // Since companies are repeated, we need to have unique yet stable key
+              key={index}
+            >
               <img
                 src={company.logoURL || defaultImage}
                 alt={`Company ${company.id}`}

--- a/src/components/InvestorsCompanies/InvestorsCompanies/InvestorsCompanies.jsx
+++ b/src/components/InvestorsCompanies/InvestorsCompanies/InvestorsCompanies.jsx
@@ -34,6 +34,7 @@ const InvestorsCompanies = ({ companies: companiesData }) => {
               <img
                 src={company.logoURL || defaultImage}
                 alt={`Company ${company.id}`}
+                title={company.name}
                 onClick={() => openModal(company)}
                 loading="lazy"
               />

--- a/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
+++ b/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
@@ -69,10 +69,10 @@ const InvestorsPeople = ({ people }) => {
     if (!peopleData) return;
 
     const intervalId = setInterval(() => {
-      peopleData.forEach((_, index) => {
-        checkPosition(index);
-      });
-    }, 10);
+      for (let i = 0; i < peopleData.length; i++) {
+        checkPosition(i);
+      }
+    }, 50);
 
     return () => clearInterval(intervalId);
   }, [peopleData, checkPosition]);

--- a/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
+++ b/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
@@ -5,7 +5,6 @@ import {
   GroupContainer,
   Container,
 } from './InvestorsPeople.styled';
-import { nanoid } from 'nanoid';
 import { useMediaQuery } from 'react-responsive';
 import { confirmTriggerZone } from '../../../helpers/confirmTriggerZone';
 import { makerGroupsToAnim } from '../../../helpers/makerGroupsToAnim';
@@ -94,13 +93,18 @@ const InvestorsPeople = ({ people }) => {
         {peopleData?.map((group, index) => (
           <GroupContainer
             id={`container-${index}`}
-            key={nanoid()}
+            // key should be static per group, so usage index is fine
+            key={`group-${index}`}
             $length={group.length}
             className={`group-${index} ${index % 2 === 0 ? 'odd-group' : 'even-group'}`}
           >
             <ul>
-              {group.map((investor) => (
-                <li key={nanoid()}>
+              {group.map((investor, investorIndex) => (
+                <li
+                  // key should be static per unique item,
+                  // but since duplicates in data occurring, index is used
+                  key={investorIndex}
+                >
                   <button
                     data-group_id={index}
                     className="item-list"

--- a/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
+++ b/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
@@ -10,12 +10,20 @@ import { confirmTriggerZone } from '../../../helpers/confirmTriggerZone';
 import { makerGroupsToAnim } from '../../../helpers/makerGroupsToAnim';
 import defaultImage from 'src/assets/investors/noname.jpg';
 
+const getFullName = (investor) => {
+  return [
+    (investor.firstName || '').trim(),
+    (investor.secondName || '').trim()
+  ].join(' ');
+}
+
 const InvestorsPeople = ({ people }) => {
   const [peopleData, setPeopleData] = useState(null);
   const [selectedInvestor, setSelectedInvestor] = useState(null);
   const [isOpen, setIsOpen] = useState(false);
   const isMobile = useMediaQuery({ maxWidth: 767 });
   const isTablet = useMediaQuery({ maxWidth: 1440 });
+  const imgStyle = { background: `rgb(212,213,209) center / contain no-repeat url(${defaultImage})`};
 
   useEffect(() => {
     const fetchData = async () => {
@@ -112,8 +120,12 @@ const InvestorsPeople = ({ people }) => {
                     onClick={() => openModal(investor)}
                   >
                     <img
-                      src={investor.imageURL ? investor.imageURL : defaultImage}
-                      alt={`Investor ${investor.id}`}
+                      // empty alt to not have broken image icon,
+                      // and have a visual fallback in background
+                      alt=""
+                      title={getFullName(investor)}
+                      src={investor.imageURL ? investor.imageURL : null}
+                      style={imgStyle}
                       loading="lazy"
                     />
                   </button>


### PR DESCRIPTION
1. Enhance fallback image 

<details>
<summary>Before</summary> 
<img width="410" alt="image" src="https://github.com/user-attachments/assets/4475f13a-a422-4977-aae7-b17daafeec8d">
</details>
<details>
<summary>After</summary> 
<img width="371" alt="image" src="https://github.com/user-attachments/assets/8f542a40-ce4a-43b2-99e7-e48de733ca49">
</details>

2. Reduce CPU load on processing investors block by:
  - Reducing re-mount of elements on each reload;
  - Reduce the frequency of checks for hide/visible state, as for this animation high frequency is not required.
