### PR TITLE
Optimise investors images

### DIFF
--- a/src/components/InvestorsCompanies/InvestorsCompanies/InvestorsCompanies.jsx
+++ b/src/components/InvestorsCompanies/InvestorsCompanies/InvestorsCompanies.jsx
@@ -33,11 +33,12 @@ const InvestorsCompanies = ({ companies: companiesData }) => {
                 key={index}
               >
                 <img
+                  loading="lazy"
+                  fetchpriority='low'
                   src={company.logoURL || defaultImage}
                   alt={`Company ${company.id}`}
                   title={company.name}
                   onClick={() => openModal(company)}
-                  loading="lazy"
                 />
               </li>
             )

--- a/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
+++ b/src/components/InvestorsCompanies/InvestorsPeople/InvestorsPeople.jsx
@@ -17,6 +17,31 @@ const getFullName = (investor) => {
   ].join(' ');
 };
 
+const getURL = (url, focalPoint) => {
+  const searchParams = new URLSearchParams();
+
+  // Specify the image dimensions and cropping mode
+  // We want processed the image to consume less bandwidth & CPU/GPU of device
+  // Check out the documentation for more information: https://www.sanity.io/docs/image-urls
+  // Set render size x2 to cover both retina and non-retina displays
+  searchParams.set('w', '360');
+  searchParams.set('h', '280');
+  searchParams.set('fit', 'crop'); // crop the image to fit the dimensions exactly
+  searchParams.set('auto', 'format'); // auto-select the best image format (webp, jpg, png)
+
+  // If focal point is configured, crop based on it as a center magnification point,
+  // so head is not cut off for example
+  if (focalPoint) {
+    searchParams.set('crop', 'focalpoint');
+    searchParams.set('fp-x', String(focalPoint.x));
+    searchParams.set('fp-y', String(focalPoint.y));
+  } else {
+    searchParams.set('crop', 'center');
+  }
+
+  return `${url}?${searchParams.toString()}`;
+};
+
 const InvestorsPeople = ({ people }) => {
   const [peopleData, setPeopleData] = useState(null);
   const [selectedInvestor, setSelectedInvestor] = useState(null);
@@ -125,10 +150,11 @@ const InvestorsPeople = ({ people }) => {
                       // empty alt to not have broken image icon,
                       // and have a visual fallback in background
                       alt=""
-                      title={getFullName(investor)}
-                      src={investor.imageURL ? investor.imageURL : null}
-                      style={imgStyle}
                       loading="lazy"
+                      fetchpriority="low"
+                      title={getFullName(investor)}
+                      src={investor.imageURL ? getURL(investor.imageURL, investor.imageFocalPoint) : null}
+                      style={imgStyle}
                     />
                   </button>
                 </li>

--- a/src/services/API.js
+++ b/src/services/API.js
@@ -1,16 +1,35 @@
 import axios from 'axios';
 
 function formImgURL(img) {
-  if (img?.asset?._ref) {
-    const imgData = img.asset._ref.split('-');
-    return `https://cdn.sanity.io/images/${
-      import.meta.env.VITE_ADMIN_PROJECT_ID
-    }/${import.meta.env.VITE_ADMIN_DATASET}/${imgData[1]}-${imgData[2]}.${
-      imgData[3]
-    }`;
-  } else {
-    return null;
+  if (!img?.asset?._ref) {
+    return null
   }
+
+  const imgData = img.asset._ref.split('-');
+
+  return `https://cdn.sanity.io/images/${
+    import.meta.env.VITE_ADMIN_PROJECT_ID
+  }/${import.meta.env.VITE_ADMIN_DATASET}/${imgData[1]}-${imgData[2]}.${
+    imgData[3]
+  }`;
+}
+
+function formImgFocalPoint(img) {
+  if (img?.hotspot) {
+    return {
+      x: img.hotspot.x,
+      y: img.hotspot.y,
+    }
+  }
+
+  if (img?.crop) {
+    return {
+      x: img.crop.left + (1 - img.crop.right) / 2,
+      y: img.crop.top + (1 - img.crop.bottom) / 2,
+    }
+  }
+
+  return null;
 }
 
 export async function fetchGoal() {
@@ -67,6 +86,7 @@ export async function fetchPeople() {
 
     const people = result.map((res) => {
       if (res.imageURL) {
+        res.imageFocalPoint = formImgFocalPoint(res.imageURL);
         res.imageURL = formImgURL(res.imageURL);
       }
       return res;

--- a/src/services/API.js
+++ b/src/services/API.js
@@ -37,7 +37,7 @@ export async function fetchGoal() {
     const {
       data: { result },
     } = await axios.get(
-      `https://${import.meta.env.VITE_ADMIN_PROJECT_ID}.api.sanity.io/${
+      `https://${import.meta.env.VITE_ADMIN_PROJECT_ID}.apicdn.sanity.io/${
         import.meta.env.VITE_ADMIN_API_VERSION
       }/data/query/${
         import.meta.env.VITE_ADMIN_DATASET
@@ -53,7 +53,7 @@ export async function fetchCompanies() {
     const {
       data: { result },
     } = await axios.get(
-      `https://${import.meta.env.VITE_ADMIN_PROJECT_ID}.api.sanity.io/${
+      `https://${import.meta.env.VITE_ADMIN_PROJECT_ID}.apicdn.sanity.io/${
         import.meta.env.VITE_ADMIN_API_VERSION
       }/data/query/${
         import.meta.env.VITE_ADMIN_DATASET
@@ -77,7 +77,7 @@ export async function fetchPeople() {
     const {
       data: { result },
     } = await axios.get(
-      `https://${import.meta.env.VITE_ADMIN_PROJECT_ID}.api.sanity.io/${
+      `https://${import.meta.env.VITE_ADMIN_PROJECT_ID}.apicdn.sanity.io/${
         import.meta.env.VITE_ADMIN_API_VERSION
       }/data/query/${
         import.meta.env.VITE_ADMIN_DATASET


### PR DESCRIPTION
Utilize sanity.io functionality for processing & caching the images: https://www.sanity.io/docs/image-urls.
Request images with the appropriate ratio & size, suitable format & focused on the face, so it doesn't be truncated in the image when possible.

Also, use "apicdn" version of sanity API to utilize API request caching. It might add ~1 minute of change propagation after the change. But since website data is not changed at live, and requests are static, we are getting speed benefits without almost any sacrifice. Read more: https://www.sanity.io/docs/api-cdn.